### PR TITLE
fix: check Linux hw architecture

### DIFF
--- a/AntivirusDeployment.yaml
+++ b/AntivirusDeployment.yaml
@@ -73,7 +73,7 @@ Resources:
     Properties:
       BucketName: !Sub cybereason-logging-${AWS::AccountId}
       LifecycleConfiguration:
-        Rules: 
+        Rules:
         - ExpirationInDays: 90
           Status: Enabled
   CybereasonDocument:
@@ -125,15 +125,17 @@ Resources:
           inputs:
             runCommand:
             - !Sub |
-                #!/bin/bash 
-                set -e 
-                if ! yum list installed | grep cybereason-sensor-${AVVersionLinux}-1 >/dev/null 2>&1; then
-                  agentPath='/tmp/cybereasonInstall/' 
-                  aws s3 cp s3://cybereasonsensor/Linux/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm $agentPath 
-                  yum install -y $agentPath/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm 
-                  rm -rf $agentPath 
+                #!/bin/bash
+                set -e
+                if [ $(uname -m) = "x86_64" ]; then
+                  if ! yum list installed | grep cybereason-sensor-${AVVersionLinux}-1 >/dev/null 2>&1; then
+                    agentPath='/tmp/cybereasonInstall/'
+                    aws s3 cp s3://cybereasonsensor/Linux/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm $agentPath
+                    yum install -y $agentPath/cybereason-sensor-${AVVersionLinux}-1.x86_64_tamedia_tamedia-r.cybereason.net_443_ACTIVE_NORMAL_rpm.rpm
+                    rm -rf $agentPath
+                  fi
                 fi
-  CybereasonDocumentAssociation:
+  Cybereasondocumentassociation:
     Type: AWS::SSM::Association
     Properties:
       OutputLocation:

--- a/AntivirusDeployment.yaml
+++ b/AntivirusDeployment.yaml
@@ -135,7 +135,7 @@ Resources:
                     rm -rf $agentPath
                   fi
                 fi
-  Cybereasondocumentassociation:
+  CybereasonDocumentAssociation:
     Type: AWS::SSM::Association
     Properties:
       OutputLocation:


### PR DESCRIPTION
Hi Vladimir and Laurent,
I wanted to ask you to take into account that some or our EC2 are running on ARM architecture and so, the antivirus script was not working.
Since I still have access to this repo, I took the liberty propose directly then change in this PR.

Note: For the moment we completely disabled the Cybereason sensor deployment on Ness and we're waiting on Jelena Radulovic for next step, so I won't be able to test this once this PR will be merged. But we can do it for the next release/patch of the cybereason sensor.

